### PR TITLE
Added version 0.0.1 of the console program

### DIFF
--- a/console.py
+++ b/console.py
@@ -1,0 +1,27 @@
+#!/usr/bin/python3
+
+"""Implements the command interpreter."""
+
+
+import cmd
+
+
+class HBNBCommand(cmd.Cmd):
+    """Defines the command interpreter."""
+
+    prompt = "(hbnb) "
+
+    @staticmethod
+    def do_quit(_) -> bool:
+        """Quit command to exit the program"""
+        return True
+
+    # `EOF` and `quit` do about the same thing so... B-)
+    do_EOF = do_quit
+
+    def emptyline(self) -> None:
+        pass
+
+
+if __name__ == "__main__":
+    HBNBCommand().cmdloop()

--- a/console.py
+++ b/console.py
@@ -2,7 +2,6 @@
 
 """Implements the command interpreter."""
 
-
 import cmd
 
 
@@ -13,14 +12,25 @@ class HBNBCommand(cmd.Cmd):
 
     @staticmethod
     def do_quit(_) -> bool:
-        """Quit command to exit the program"""
+        """Quit command to exit the program."""
         return True
 
-    # `EOF` and `quit` do about the same thing so... B-)
-    do_EOF = do_quit
+    @staticmethod
+    def do_eof(_) -> bool:
+        """Handles the Ctrl+D signal (EOF)."""
+        print()
+        return True
 
     def emptyline(self) -> None:
         pass
+
+    def default(self, line: str) -> None:
+        print(f"Unknown command: {line}")
+
+    def precmd(self, line):
+        if line and line == "EOF":
+            return line.lower()
+        return line
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I've added the initial version of the command interpreter. It correctly handles the requirements given.
I implemented the `quit` and `EOF` commands, here are their signatures

```python
@staticmethod
def do_quit(_) -> bool:
   ....

do_EOF = do_quit
```
The `do_EOF` and `do_quit` methods do about the same thing, so instead of writing a new method for `do_EOF`, it simply references `do_quit` and behaves exactly like it.

To ensure that empty lines do not execute anything, I overrode the `emptyline()` method.

Here's a screenshot of it in action.

![image](https://github.com/nanafox/AirBnB_clone/assets/48143641/f5f87f27-29a2-423b-950a-68e060c079bd)
